### PR TITLE
Chore/test extras importorskip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,19 @@ test = [
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.10.0",
+    "pytest-xdist>=3.5.0",
     "httpx>=0.24.0",
     "responses>=0.23.0",
+    # Optional test-time dependencies used by functional/integration tests
+    # Note: sseclient package name on PyPI is sseclient-py, which imports as "sseclient"
+    "sseclient-py>=1.7.2",
+    "jsonschema>=4.20.0",
+    # Telemetry required by the API app during tests
+    "opentelemetry-api>=1.26.0",
+    "opentelemetry-sdk>=1.26.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.26.0",
+    "opentelemetry-instrumentation-openai>=0.46.0",
+    "azure-monitor-opentelemetry-exporter>=1.0.0b11",
 ]
 docs = [
     "sphinx>=7.0.0",

--- a/scripts/seed_search_index.py
+++ b/scripts/seed_search_index.py
@@ -95,9 +95,10 @@ def get_embedding(client: AzureOpenAI, text: str) -> List[float]:
 # --------------------------------------------------------------------------- #
 def main(dirpath: pathlib.Path, top: int | None):
     # ----- clients -----
+    index_name = os.getenv("AZURE_SEARCH_INDEX_NAME", "confluence-graph-embeddings-v2")
     search = SearchClient(
         os.environ["AZURE_SEARCH_ENDPOINT"],
-        index_name="confluence-graph-embeddings-v2",
+        index_name=index_name,
         credential=AzureKeyCredential(os.environ["AZURE_SEARCH_KEY"]),
     )
     aoai = AzureOpenAI(

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -4,3 +4,11 @@ Functional tests for the Confluence Q&A API.
 These tests verify the end-to-end functionality of the API endpoints,
 including /ask, SSE tracing, and space filtering.
 """
+
+# Ensure optional SSE dependency is present; skip functional tests otherwise
+import pytest
+
+pytest.importorskip(
+    "sseclient",
+    reason="Optional dependency for SSE-based functional tests (install via .[test])",
+)


### PR DESCRIPTION
## Summary by Sourcery

Add optional test-time dependencies for functional/integration and telemetry tests, parameterize the Azure Search index name in the seed_search_index script, and initialize the functional tests package

Enhancements:
- Make seed_search_index script read AZURE_SEARCH_INDEX_NAME from the environment with a default value

Build:
- Add pytest-xdist, sseclient-py, jsonschema, and OpenTelemetry dependencies to test extras in pyproject.toml

Tests:
- Add __init__.py to tests/functional to enable the functional tests package structure