### PR TITLE
tests: add app factory for test compatibility; alias AzureDataStore t…

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -30,6 +30,14 @@ def health():
     return {"ok": True}
 
 
+def create_app() -> FastAPI:
+    """Compatibility factory for tests that expect a create_app() function.
+
+    Returns the already-initialized FastAPI application instance.
+    """
+    return app
+
+
 @app.post("/api/ask")
 def ask(payload: dict = Body(...)):
     """Main ask endpoint that integrates with orchestrator."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ requires-python = ">=3.9"
 dependencies = [
     # AutoGen Framework
     "pyautogen>=0.2.0",
+    "autogen>=0.9.0",
 
     # Azure Services
     "azure-identity>=1.15.0",


### PR DESCRIPTION
…o SessionStore and allow injected store; make AutoGen calls async-safe and add JSON fallbacks; ensure autogen is installed

## Summary by Sourcery

Improve test compatibility and robustness of orchestrator by introducing dependency injection and backwards aliases, offloading synchronous AutoGen calls to threads, adding JSON parsing fallbacks, and updating dependencies.

New Features:
- Add AzureDataStore alias for backward compatibility in tests
- Allow injecting custom SessionStore into Orchestrator for test compatibility
- Add create_app() factory function for tests in the FastAPI app

Enhancements:
- Offload synchronous AutoGen initiate_chat calls to threads for async safety
- Add fallback logic for non-JSON AutoGen responses in query analysis and verification
- Bypass clarification step for atomic queries to avoid unnecessary blocking
- Ensure thinking log entries are JSON-serializable before storing

Build:
- Add autogen>=0.9.0 dependency to pyproject.toml to ensure AutoGen installation